### PR TITLE
Add horizontal observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ collect_simulated_experiment_data(
     *[
         HoneycombLayout(
             noise=p,
-            tile_diam=d,
+            tile_width=d,
+            tile_height=d,
             sub_rounds=30,
             style="SD6",
         )
         for d in [2, 3, 4]
-        for p in np.geomspace(start=5e-4, stop=3e-3, num=5)
+        for p in [0.001, 0.002, 0.003]
     ],
     out_path="test.csv",
     discard_previous_data=True,

--- a/src/circuit_diagrams.py
+++ b/src/circuit_diagrams.py
@@ -6,6 +6,8 @@ from typing import Iterator, List, Dict, Any, Tuple
 
 import stim
 
+from noise import ANY_CLIFFORD_2_OPS
+
 
 def _iter_circuit(c: stim.Circuit, reps: int, nested: int) -> Iterator[stim.CircuitInstruction]:
     for _ in range(reps):
@@ -132,11 +134,11 @@ def plot_circuit(c: stim.Circuit, only_repeat_block: bool):
                 i2q[q] = p
                 assert p not in seen_coords
                 seen_coords.add(p)
-        elif op.name in ["M", "R", "H", "H_YZ", "C_XYZ", "MR", "MY", "MX"]:
+        elif op.name in ["M", "R", "H", "H_YZ", "C_XYZ", "C_ZYX", "MR", "MY", "MX"]:
             s = op.name
             if op.name == "H_YZ":
                 s = "G"
-            if op.name == "C_XYZ":
+            if op.name == "C_XYZ" or op.name == "C_ZYX":
                 s = "C"
             if op.name == "MX" or op.name == "MY":
                 s = "m"
@@ -146,7 +148,7 @@ def plot_circuit(c: stim.Circuit, only_repeat_block: bool):
                 q = i2q[t.value]
                 assert q not in cur_level
                 cur_level[q] = s
-        elif op.name in ["CX", "XCX", "YCX", "YCX", "YCZ", "XCY"]:
+        elif op.name in ANY_CLIFFORD_2_OPS:
             qs = [t.value for t in op.targets_copy()]
             for k in range(0, len(qs), 2):
                 q1 = i2q[qs[k]]

--- a/src/circuit_diagrams_test.py
+++ b/src/circuit_diagrams_test.py
@@ -17,7 +17,8 @@ def assert_same_diagram(actual, expected):
 def test_plot_SD6():
     assert_same_diagram(plot_circuit(generate_honeycomb_circuit(
         noise=0.001,
-        tile_diam=1,
+        tile_width=1,
+        tile_height=1,
         sub_rounds=13,
         style="SD6",
     ), only_repeat_block=True), r"""
@@ -64,7 +65,8 @@ def test_plot_SD6():
 def test_plot_PC3():
     assert_same_diagram(plot_circuit(generate_honeycomb_circuit(
         noise=0.001,
-        tile_diam=1,
+        tile_width=1,
+        tile_height=1,
         sub_rounds=20,
         style="PC3",
     ), only_repeat_block=True), r"""
@@ -97,7 +99,8 @@ def test_plot_PC3():
 def test_plot_EM3():
     assert_same_diagram(plot_circuit(generate_honeycomb_circuit(
         noise=0.001,
-        tile_diam=2,
+        tile_width=2,
+        tile_height=2,
         sub_rounds=20,
         style="EM3",
     ), only_repeat_block=True), r"""

--- a/src/circuit_diagrams_test.py
+++ b/src/circuit_diagrams_test.py
@@ -1,5 +1,6 @@
 from circuit_diagrams import plot_circuit
 from honeycomb_circuit import generate_honeycomb_circuit
+from honeycomb_layout import HoneycombLayout
 
 
 def assert_same_diagram(actual, expected):
@@ -15,13 +16,14 @@ def assert_same_diagram(actual, expected):
 
 
 def test_plot_SD6():
-    assert_same_diagram(plot_circuit(generate_honeycomb_circuit(
+    assert_same_diagram(plot_circuit(generate_honeycomb_circuit(HoneycombLayout(
         noise=0.001,
         tile_width=1,
         tile_height=1,
         sub_rounds=13,
         style="SD6",
-    ), only_repeat_block=True), r"""
+        obs="V",
+    )), only_repeat_block=True), r"""
                                                                                                             ~
                                                                                                             |
                                                                           ~                                 |
@@ -63,13 +65,14 @@ def test_plot_SD6():
 
 
 def test_plot_PC3():
-    assert_same_diagram(plot_circuit(generate_honeycomb_circuit(
+    assert_same_diagram(plot_circuit(generate_honeycomb_circuit(HoneycombLayout(
         noise=0.001,
         tile_width=1,
         tile_height=1,
         sub_rounds=20,
         style="PC3",
-    ), only_repeat_block=True), r"""
+        obs="V",
+    )), only_repeat_block=True), r"""
                                                 ~
                          ~                      |
                         M|                      X                       X ~
@@ -97,13 +100,14 @@ def test_plot_PC3():
 
 
 def test_plot_EM3():
-    assert_same_diagram(plot_circuit(generate_honeycomb_circuit(
+    assert_same_diagram(plot_circuit(generate_honeycomb_circuit(HoneycombLayout(
         noise=0.001,
         tile_width=2,
         tile_height=2,
         sub_rounds=20,
         style="EM3",
-    ), only_repeat_block=True), r"""
+        obs="V",
+    )), only_repeat_block=True), r"""
                         ~                                                                       ~
                         |                                                ~                      |                                                ~
          ~--y           y           y-----------y ~         y           y+----------y           y           y-----------y ~         y           y+-~

--- a/src/collect_data.py
+++ b/src/collect_data.py
@@ -6,7 +6,7 @@ from decoding import sample_decode_count_correct
 from honeycomb_circuit import generate_honeycomb_circuit
 from honeycomb_layout import HoneycombLayout
 
-CSV_HEADER = "tile_diam,sub_rounds,physical_error_rate,circuit_style,num_shots,num_correct,total_processing_seconds"
+CSV_HEADER = "tile_width,tile_height,sub_rounds,physical_error_rate,circuit_style,num_shots,num_correct,total_processing_seconds"
 
 
 def collect_simulated_experiment_data(*cases: HoneycombLayout,
@@ -62,7 +62,8 @@ def collect_simulated_experiment_data(*cases: HoneycombLayout,
         while True:
             t0 = time.monotonic()
             circuit = generate_honeycomb_circuit(
-                tile_diam=lay.tile_diam,
+                tile_width=lay.tile_width,
+                tile_height=lay.tile_height,
                 sub_rounds=lay.sub_rounds,
                 noise=lay.noise,
                 style=lay.style,
@@ -73,7 +74,7 @@ def collect_simulated_experiment_data(*cases: HoneycombLayout,
                 use_internal_decoder=use_internal_decoder,
             )
             t1 = time.monotonic()
-            record = f"{lay.tile_diam},{lay.sub_rounds},{lay.noise},{lay.style},{num_next_shots},{num_correct},{t1 - t0}"
+            record = f"{lay.tile_width},{lay.tile_height},{lay.sub_rounds},{lay.noise},{lay.style},{num_next_shots},{num_correct},{t1 - t0}"
             with open(out_path, "a") as f:
                 print(record, file=f)
             print(record)

--- a/src/collect_data.py
+++ b/src/collect_data.py
@@ -61,13 +61,7 @@ def collect_simulated_experiment_data(*cases: HoneycombLayout,
         total_shots = 0
         while True:
             t0 = time.monotonic()
-            circuit = generate_honeycomb_circuit(
-                tile_width=lay.tile_width,
-                tile_height=lay.tile_height,
-                sub_rounds=lay.sub_rounds,
-                noise=lay.noise,
-                style=lay.style,
-            )
+            circuit = generate_honeycomb_circuit(lay)
             num_correct = sample_decode_count_correct(
                 num_shots=num_next_shots,
                 circuit=circuit,

--- a/src/collect_data_test.py
+++ b/src/collect_data_test.py
@@ -16,6 +16,7 @@ def test_collect_and_plot():
                     tile_height=d,
                     sub_rounds=30,
                     style="SD6",
+                    obs="V",
                 )
                 for p in [1e-5, 1e-4]
                 for d in [1, 2]
@@ -28,4 +29,4 @@ def test_collect_and_plot():
             min_seen_logical_errors=1,
         )
 
-        plot_data(f, show=True, out_path=d + "/tmp.png", title="Test")
+        plot_data(f, show=False, out_path=d + "/tmp.png", title="Test")

--- a/src/collect_data_test.py
+++ b/src/collect_data_test.py
@@ -1,0 +1,31 @@
+import tempfile
+
+from collect_data import collect_simulated_experiment_data
+from honeycomb_layout import HoneycombLayout
+from plotting import plot_data
+
+
+def test_collect_and_plot():
+    with tempfile.TemporaryDirectory() as d:
+        f = d + "/tmp.csv"
+        collect_simulated_experiment_data(
+            *[
+                HoneycombLayout(
+                    noise=p,
+                    tile_width=d,
+                    tile_height=d,
+                    sub_rounds=30,
+                    style="SD6",
+                )
+                for p in [1e-5, 1e-4]
+                for d in [1, 2]
+            ],
+            out_path=f,
+            discard_previous_data=True,
+            min_shots=10,
+            max_shots=10,
+            max_sample_std_dev=1,
+            min_seen_logical_errors=1,
+        )
+
+        plot_data(f, show=True, out_path=d + "/tmp.png", title="Test")

--- a/src/decoding_test.py
+++ b/src/decoding_test.py
@@ -15,7 +15,8 @@ def test_internal_decoder_actually_runs(tile_diam: int, sub_rounds: int, style: 
     sample_decode_count_correct(
         num_shots=100,
         circuit=generate_honeycomb_circuit(
-            tile_diam=tile_diam,
+            tile_width=tile_diam,
+            tile_height=tile_diam,
             sub_rounds=sub_rounds,
             noise=0.001,
             style=style,

--- a/src/decoding_test.py
+++ b/src/decoding_test.py
@@ -4,22 +4,25 @@ import pytest
 
 from decoding import sample_decode_count_correct, internal_decoder_path
 from honeycomb_circuit import generate_honeycomb_circuit
+from honeycomb_layout import HoneycombLayout
 
 
-@pytest.mark.parametrize('tile_diam,sub_rounds,style', itertools.product(
+@pytest.mark.parametrize('tile_diam,sub_rounds,style,obs', itertools.product(
     range(1, 5),
     range(1, 24),
     ["PC3", "SD6", "EM3"],
+    ["H", "V"]
 ) if internal_decoder_path() is not None else [])
-def test_internal_decoder_actually_runs(tile_diam: int, sub_rounds: int, style: str):
+def test_internal_decoder_actually_runs(tile_diam: int, sub_rounds: int, style: str, obs: str):
     sample_decode_count_correct(
         num_shots=100,
-        circuit=generate_honeycomb_circuit(
+        circuit=generate_honeycomb_circuit(HoneycombLayout(
             tile_width=tile_diam,
             tile_height=tile_diam,
             sub_rounds=sub_rounds,
             noise=0.001,
             style=style,
-        ),
+            obs=obs,
+        )),
         use_internal_decoder=True,
     )

--- a/src/honeycomb_circuit.py
+++ b/src/honeycomb_circuit.py
@@ -1,5 +1,4 @@
-import dataclasses
-from typing import List, Sequence, Tuple, Union, Optional
+from typing import List, Tuple, Optional
 
 import stim
 
@@ -8,7 +7,8 @@ from measure_tracker import MeasurementTracker, Prev
 from noise import NoiseModel
 
 
-def generate_honeycomb_circuit(tile_diam: int,
+def generate_honeycomb_circuit(tile_width: int,
+                               tile_height: int,
                                sub_rounds: int,
                                noise: float,
                                style: str,
@@ -17,13 +17,23 @@ def generate_honeycomb_circuit(tile_diam: int,
 
     Performs fault tolerant initialization, idling, and measurement.
 
+    Args:
+        tile_width: The number of times to horizontally repeat the tiling unit of the code.
+        tile_height: The number of times to vertically repeat the tiling unit of the code.
+        sub_rounds: The number of edge parity measurements to perform (counting X, Y, and Z
+            separately).
+        noise: Determines the strength of noisy operations, relative to the error model.
+        style: Determines details of the circuit layout and the error model used. Valid values are
+            "SD6", "EM3", "CP3", and "SI7".
+
     Reference:
         "Dynamically Generated Logical Qubits"
         Matthew B. Hastings, Jeongwan Haah
         https://arxiv.org/abs/2107.02194
     """
     lay = HoneycombLayout(
-        tile_diam=tile_diam,
+        tile_width=tile_width,
+        tile_height=tile_height,
         sub_rounds=sub_rounds,
         noise=noise,
         style=style,

--- a/src/honeycomb_circuit.py
+++ b/src/honeycomb_circuit.py
@@ -48,9 +48,6 @@ def fault_tolerant_init(lay: HoneycombLayout, mtrack: MeasurementTracker) -> sti
 
     init_basis = lay.obs_before_sub_round(0)[0]
     if init_basis != "Z":
-        # if lay.style == "SD6":
-        #     result.append_operation(f"H_YZ", lay.data_qubit_indices)
-        # else:
         result.append_operation(f"H_{init_basis}Z", lay.data_qubit_indices)
         result.append_operation("TICK", [])
 

--- a/src/honeycomb_circuit_test.py
+++ b/src/honeycomb_circuit_test.py
@@ -6,14 +6,20 @@ from honeycomb_circuit import generate_honeycomb_circuit
 from hack_pycharm_pybind_pytest_workaround import stim
 
 
-@pytest.mark.parametrize('tile_diam,sub_rounds,style', itertools.product(
+@pytest.mark.parametrize('tile_width,tile_height_extra,sub_rounds,style', itertools.product(
     range(1, 5),
+    range(2),
     range(1, 24),
     ["PC3", "SD6", "EM3"],
 ))
-def test_circuit_has_decomposing_error_model(tile_diam: int, sub_rounds: int, style: str):
+def test_circuit_has_decomposing_error_model(
+        tile_width: int,
+        tile_height_extra: int,
+        sub_rounds: int,
+        style: str):
     circuit = generate_honeycomb_circuit(
-        tile_diam=tile_diam,
+        tile_width=tile_width,
+        tile_height=tile_width + tile_height_extra,
         sub_rounds=sub_rounds,
         noise=0.001,
         style=style,
@@ -23,7 +29,8 @@ def test_circuit_has_decomposing_error_model(tile_diam: int, sub_rounds: int, st
 
 def test_circuit_details_SD6():
     actual = generate_honeycomb_circuit(
-        tile_diam=1,
+        tile_width=1,
+        tile_height=1,
         sub_rounds=1003,
         noise=0.001,
         style="SD6",
@@ -270,7 +277,8 @@ def test_circuit_details_SD6():
 
 def test_circuit_details_PC3():
     actual = generate_honeycomb_circuit(
-        tile_diam=1,
+        tile_width=1,
+        tile_height=1,
         sub_rounds=1003,
         noise=0.001,
         style="PC3",
@@ -475,7 +483,8 @@ def test_circuit_details_PC3():
 
 def test_circuit_details_EM3():
     actual = generate_honeycomb_circuit(
-        tile_diam=1,
+        tile_width=1,
+        tile_height=1,
         sub_rounds=1003,
         noise=0.001,
         style="EM3",

--- a/src/honeycomb_circuit_test.py
+++ b/src/honeycomb_circuit_test.py
@@ -11,14 +11,14 @@ from honeycomb_layout import HoneycombLayout
     range(1, 5),
     range(2),
     range(1, 24),
-    [1, 2],
+    ["H", "V"],
     ["PC3", "SD6", "EM3"],
 ))
 def test_circuit_has_decomposing_error_model(
         tile_width: int,
         tile_height_extra: int,
         sub_rounds: int,
-        obs: int,
+        obs: str,
         style: str):
     circuit = generate_honeycomb_circuit(HoneycombLayout(
         tile_width=tile_width,
@@ -26,8 +26,7 @@ def test_circuit_has_decomposing_error_model(
         sub_rounds=sub_rounds,
         noise=0.001,
         style=style,
-        v_obs=bool(obs & 1),
-        h_obs=bool(obs & 2),
+        obs=obs,
     ))
     _ = circuit.detector_error_model(decompose_errors=True)
 
@@ -39,8 +38,7 @@ def test_circuit_details_SD6():
         sub_rounds=1003,
         noise=0.001,
         style="SD6",
-        v_obs=True,
-        h_obs=False,
+        obs="V",
     ))
     cleaned = stim.Circuit(str(actual))
     assert cleaned == stim.Circuit("""
@@ -293,8 +291,7 @@ def test_circuit_details_PC3():
         sub_rounds=1003,
         noise=0.001,
         style="PC3",
-        v_obs=True,
-        h_obs=False,
+        obs="V",
     ))
     cleaned = stim.Circuit(str(actual))
     assert cleaned == stim.Circuit("""
@@ -501,8 +498,7 @@ def test_circuit_details_EM3():
         sub_rounds=1003,
         noise=0.001,
         style="EM3",
-        v_obs=True,
-        h_obs=False,
+        obs="V",
     ))
     cleaned = stim.Circuit(str(actual))
     assert cleaned == stim.Circuit("""
@@ -597,8 +593,7 @@ def test_circuit_details_EM3_h_obs():
         sub_rounds=1003,
         noise=0.001,
         style="EM3",
-        v_obs=False,
-        h_obs=True,
+        obs="H",
     ))
     cleaned = stim.Circuit(str(actual))
     assert cleaned == stim.Circuit("""

--- a/src/honeycomb_circuit_test.py
+++ b/src/honeycomb_circuit_test.py
@@ -79,7 +79,7 @@ def test_circuit_details_SD6():
         TICK
 
         R 13 16 19 21 25 28
-        C_XYZ 0 2 4 7 9 11
+        C_ZYX 0 2 4 7 9 11
         X_ERROR(0.001) 13 16 19 21 25 28
         DEPOLARIZE1(0.001) 0 2 4 7 9 11 1 3 5 6 8 10 12 14 15 17 18 20 22 23 24 26 27 29
         TICK
@@ -90,7 +90,7 @@ def test_circuit_details_SD6():
         TICK
 
         R 12 17 20 23 26 29
-        C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
+        C_ZYX 0 1 2 3 4 5 6 7 8 9 10 11
         X_ERROR(0.001) 12 17 20 23 26 29
         DEPOLARIZE1(0.001) 0 1 2 3 4 5 6 7 8 9 10 11 13 14 15 16 18 19 21 22 24 25 27 28
         TICK
@@ -103,7 +103,7 @@ def test_circuit_details_SD6():
 
         X_ERROR(0.001) 13 16 19 21 25 28
         R 14 15 18 22 24 27
-        C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
+        C_ZYX 0 1 2 3 4 5 6 7 8 9 10 11
         M 13 16 19 21 25 28
         OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
         SHIFT_COORDS(0, 0, 1)
@@ -119,7 +119,7 @@ def test_circuit_details_SD6():
 
         X_ERROR(0.001) 12 17 20 23 26 29
         R 13 16 19 21 25 28
-        C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
+        C_ZYX 0 1 2 3 4 5 6 7 8 9 10 11
         M 12 17 20 23 26 29
         OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
         DETECTOR(0, 2, 0) rec[-12] rec[-11] rec[-8] rec[-6] rec[-5] rec[-2]
@@ -137,7 +137,7 @@ def test_circuit_details_SD6():
 
         X_ERROR(0.001) 14 15 18 22 24 27
         R 12 17 20 23 26 29
-        C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
+        C_ZYX 0 1 2 3 4 5 6 7 8 9 10 11
         M 14 15 18 22 24 27
         OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
         SHIFT_COORDS(0, 0, 1)
@@ -153,7 +153,7 @@ def test_circuit_details_SD6():
 
         X_ERROR(0.001) 13 16 19 21 25 28
         R 14 15 18 22 24 27
-        C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
+        C_ZYX 0 1 2 3 4 5 6 7 8 9 10 11
         M 13 16 19 21 25 28
         OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
         DETECTOR(0, 4, 0) rec[-24] rec[-22] rec[-19] rec[-12] rec[-10] rec[-7] rec[-6] rec[-4] rec[-1]
@@ -172,7 +172,7 @@ def test_circuit_details_SD6():
 
             X_ERROR(0.001) 12 17 20 23 26 29
             R 13 16 19 21 25 28
-            C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
+            C_ZYX 0 1 2 3 4 5 6 7 8 9 10 11
             M 12 17 20 23 26 29
             OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
             DETECTOR(0, 2, 0) rec[-30] rec[-29] rec[-26] rec[-24] rec[-23] rec[-20] rec[-12] rec[-11] rec[-8] rec[-6] rec[-5] rec[-2]
@@ -190,7 +190,7 @@ def test_circuit_details_SD6():
 
             X_ERROR(0.001) 14 15 18 22 24 27
             R 12 17 20 23 26 29
-            C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
+            C_ZYX 0 1 2 3 4 5 6 7 8 9 10 11
             M 14 15 18 22 24 27
             OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
             DETECTOR(0, 0, 0) rec[-30] rec[-28] rec[-25] rec[-24] rec[-23] rec[-20] rec[-12] rec[-10] rec[-7] rec[-6] rec[-5] rec[-2]
@@ -208,7 +208,7 @@ def test_circuit_details_SD6():
 
             X_ERROR(0.001) 13 16 19 21 25 28
             R 14 15 18 22 24 27
-            C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
+            C_ZYX 0 1 2 3 4 5 6 7 8 9 10 11
             M 13 16 19 21 25 28
             OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
             DETECTOR(0, 4, 0) rec[-30] rec[-28] rec[-25] rec[-24] rec[-22] rec[-19] rec[-12] rec[-10] rec[-7] rec[-6] rec[-4] rec[-1]
@@ -227,7 +227,7 @@ def test_circuit_details_SD6():
 
         X_ERROR(0.001) 12 17 20 23 26 29
         R 13 16 19 21 25 28
-        C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
+        C_ZYX 0 1 2 3 4 5 6 7 8 9 10 11
         M 12 17 20 23 26 29
         OBSERVABLE_INCLUDE(0) rec[-5] rec[-4]
         DETECTOR(0, 2, 0) rec[-30] rec[-29] rec[-26] rec[-24] rec[-23] rec[-20] rec[-12] rec[-11] rec[-8] rec[-6] rec[-5] rec[-2]
@@ -252,7 +252,7 @@ def test_circuit_details_SD6():
         DEPOLARIZE1(0.001) 0 1 2 3 4 5 6 7 8 9 10 11 12 13 16 17 19 20 21 23 25 26 28 29
         TICK
 
-        C_XYZ 1 3 5 6 8 10
+        C_ZYX 1 3 5 6 8 10
         DEPOLARIZE1(0.001) 1 3 5 6 8 10 0 2 4 7 9 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
         TICK
 
@@ -269,6 +269,10 @@ def test_circuit_details_SD6():
         SHIFT_COORDS(0, 0, 1)
         C_XYZ 0 1 2 3 4 5 6 7 8 9 10 11
         DEPOLARIZE1(0.001) 0 1 2 3 4 5 6 7 8 9 10 11 12 14 15 17 18 20 22 23 24 26 27 29
+        TICK
+
+        H_YZ 0 1 2 3 4 5 6 7 8 9 10 11
+        DEPOLARIZE1(0.001) 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
         TICK
 
         X_ERROR(0.001) 0 1 2 3 4 5 6 7 8 9 10 11
@@ -583,4 +587,122 @@ def test_circuit_details_EM3():
         DETECTOR(0, 4, 0) rec[-24] rec[-22] rec[-19] rec[-18] rec[-16] rec[-13] rec[-9] rec[-8] rec[-7] rec[-3] rec[-2] rec[-1]
         DETECTOR(2, 1, 0) rec[-23] rec[-21] rec[-20] rec[-17] rec[-15] rec[-14] rec[-12] rec[-11] rec[-10] rec[-6] rec[-5] rec[-4]
         OBSERVABLE_INCLUDE(0) rec[-11] rec[-10] rec[-8] rec[-7]
+    """)
+
+
+def test_circuit_details_EM3_h_obs():
+    actual = generate_honeycomb_circuit(HoneycombLayout(
+        tile_width=1,
+        tile_height=1,
+        sub_rounds=1003,
+        noise=0.001,
+        style="EM3",
+        v_obs=False,
+        h_obs=True,
+    ))
+    cleaned = stim.Circuit(str(actual))
+    assert cleaned == stim.Circuit("""
+        QUBIT_COORDS(1, 0) 0
+        QUBIT_COORDS(1, 1) 1
+        QUBIT_COORDS(1, 2) 2
+        QUBIT_COORDS(1, 3) 3
+        QUBIT_COORDS(1, 4) 4
+        QUBIT_COORDS(1, 5) 5
+        QUBIT_COORDS(3, 0) 6
+        QUBIT_COORDS(3, 1) 7
+        QUBIT_COORDS(3, 2) 8
+        QUBIT_COORDS(3, 3) 9
+        QUBIT_COORDS(3, 4) 10
+        QUBIT_COORDS(3, 5) 11
+
+        R 0 1 2 3 4 5 6 7 8 9 10 11
+        X_ERROR(0.001) 0 1 2 3 4 5 6 7 8 9 10 11
+        TICK
+
+        H 0 1 2 3 4 5 6 7 8 9 10 11
+        DEPOLARIZE1(0.001) 0 1 2 3 4 5 6 7 8 9 10 11
+        TICK
+
+        # X subround. Compare X parities to X initializations.
+        DEPOLARIZE2(0.001) 9 3 2 1 4 5 0 6 7 8 11 10
+        MPP(0.001) X9*X3 X2*X1 X4*X5 X0*X6 X7*X8 X11*X10
+        OBSERVABLE_INCLUDE(1) rec[-3]
+        DETECTOR(0, 3, 0) rec[-6]
+        DETECTOR(1, 1.5, 0) rec[-5]
+        DETECTOR(1, 4.5, 0) rec[-4]
+        DETECTOR(2, 0, 0) rec[-3]
+        DETECTOR(3, 1.5, 0) rec[-2]
+        DETECTOR(3, 4.5, 0) rec[-1]
+        SHIFT_COORDS(0, 0, 1)
+        TICK
+
+        # Y subround. Get X*Y=Z stabilizers for first time.
+        DEPOLARIZE2(0.001) 7 1 2 3 0 5 4 10 9 8 11 6
+        MPP(0.001) Y7*Y1 Y2*Y3 Y0*Y5 Y4*Y10 Y9*Y8 Y11*Y6
+        OBSERVABLE_INCLUDE(1) rec[-6]
+        SHIFT_COORDS(0, 0, 1)
+        TICK
+
+        # Z subround. Get Y*Z=X stabilizers to compare against initialization.
+        DEPOLARIZE2(0.001) 11 5 0 1 4 3 2 8 7 6 9 10
+        MPP(0.001) Z11*Z5 Z0*Z1 Z4*Z3 Z2*Z8 Z7*Z6 Z9*Z10
+        OBSERVABLE_INCLUDE(1) rec[-5] rec[-2]
+        DETECTOR(0, 0, 0) rec[-12] rec[-10] rec[-7] rec[-6] rec[-5] rec[-2]
+        DETECTOR(2, 3, 0) rec[-11] rec[-9] rec[-8] rec[-4] rec[-3] rec[-1]
+        SHIFT_COORDS(0, 0, 1)
+        TICK
+
+        # X subround. Get Z*X=Y stabilizers for the first time.
+        DEPOLARIZE2(0.001) 9 3 2 1 4 5 0 6 7 8 11 10
+        MPP(0.001) X9*X3 X2*X1 X4*X5 X0*X6 X7*X8 X11*X10
+        OBSERVABLE_INCLUDE(1) rec[-3]
+        SHIFT_COORDS(0, 0, 1)
+        TICK
+
+        REPEAT 333 {
+            # Y subround. Get X*Y = Z stabilizers to compare against last time.
+            DEPOLARIZE2(0.001) 7 1 2 3 0 5 4 10 9 8 11 6
+            MPP(0.001) Y7*Y1 Y2*Y3 Y0*Y5 Y4*Y10 Y9*Y8 Y11*Y6
+            OBSERVABLE_INCLUDE(1) rec[-6]
+            DETECTOR(0, 2, 0) rec[-30] rec[-29] rec[-26] rec[-24] rec[-23] rec[-20] rec[-12] rec[-11] rec[-8] rec[-6] rec[-5] rec[-2]
+            DETECTOR(2, 5, 0) rec[-28] rec[-27] rec[-25] rec[-22] rec[-21] rec[-19] rec[-10] rec[-9] rec[-7] rec[-4] rec[-3] rec[-1]
+            SHIFT_COORDS(0, 0, 1)
+            TICK
+
+            # Z subround. Get Y*Z = X stabilizers to compare against last time.
+            DEPOLARIZE2(0.001) 11 5 0 1 4 3 2 8 7 6 9 10
+            MPP(0.001) Z11*Z5 Z0*Z1 Z4*Z3 Z2*Z8 Z7*Z6 Z9*Z10
+            OBSERVABLE_INCLUDE(1) rec[-5] rec[-2]
+            DETECTOR(0, 0, 0) rec[-30] rec[-28] rec[-25] rec[-24] rec[-23] rec[-20] rec[-12] rec[-10] rec[-7] rec[-6] rec[-5] rec[-2]
+            DETECTOR(2, 3, 0) rec[-29] rec[-27] rec[-26] rec[-22] rec[-21] rec[-19] rec[-11] rec[-9] rec[-8] rec[-4] rec[-3] rec[-1]
+            SHIFT_COORDS(0, 0, 1)
+            TICK
+
+            # X subround. Get Z*X = Y stabilizers to compare against last time.
+            DEPOLARIZE2(0.001) 9 3 2 1 4 5 0 6 7 8 11 10
+            MPP(0.001) X9*X3 X2*X1 X4*X5 X0*X6 X7*X8 X11*X10
+            OBSERVABLE_INCLUDE(1) rec[-3]
+            DETECTOR(0, 4, 0) rec[-30] rec[-28] rec[-25] rec[-24] rec[-22] rec[-19] rec[-12] rec[-10] rec[-7] rec[-6] rec[-4] rec[-1]
+            DETECTOR(2, 1, 0) rec[-29] rec[-27] rec[-26] rec[-23] rec[-21] rec[-20] rec[-11] rec[-9] rec[-8] rec[-5] rec[-3] rec[-2]
+            SHIFT_COORDS(0, 0, 1)
+            TICK
+        }
+
+        H 0 1 2 3 4 5 6 7 8 9 10 11
+        DEPOLARIZE1(0.001) 0 1 2 3 4 5 6 7 8 9 10 11
+        TICK
+
+        X_ERROR(0.001) 0 1 2 3 4 5 6 7 8 9 10 11
+        M 0 1 2 3 4 5 6 7 8 9 10 11
+        # Compare X data measurements to X parity measurements from last subround.
+        DETECTOR(0, 3, 0) rec[-18] rec[-9] rec[-3]
+        DETECTOR(1, 1.5, 0) rec[-17] rec[-11] rec[-10]
+        DETECTOR(1, 4.5, 0) rec[-16] rec[-8] rec[-7]
+        DETECTOR(2, 0, 0) rec[-15] rec[-12] rec[-6]
+        DETECTOR(3, 1.5, 0) rec[-14] rec[-5] rec[-4]
+        DETECTOR(3, 4.5, 0) rec[-13] rec[-2] rec[-1]
+        # Compare X data measurements to previous X stabilizer reconstruction.
+        DETECTOR(0, 0, 0) rec[-30] rec[-28] rec[-25] rec[-24] rec[-23] rec[-20] rec[-12] rec[-11] rec[-7] rec[-6] rec[-5] rec[-1]
+        DETECTOR(2, 3, 0) rec[-29] rec[-27] rec[-26] rec[-22] rec[-21] rec[-19] rec[-10] rec[-9] rec[-8] rec[-4] rec[-3] rec[-2]
+        OBSERVABLE_INCLUDE(1) rec[-11] rec[-5]
     """)

--- a/src/honeycomb_circuit_test.py
+++ b/src/honeycomb_circuit_test.py
@@ -4,37 +4,44 @@ import pytest
 
 from honeycomb_circuit import generate_honeycomb_circuit
 from hack_pycharm_pybind_pytest_workaround import stim
+from honeycomb_layout import HoneycombLayout
 
 
-@pytest.mark.parametrize('tile_width,tile_height_extra,sub_rounds,style', itertools.product(
+@pytest.mark.parametrize('tile_width,tile_height_extra,sub_rounds,obs,style', itertools.product(
     range(1, 5),
     range(2),
     range(1, 24),
+    [1, 2],
     ["PC3", "SD6", "EM3"],
 ))
 def test_circuit_has_decomposing_error_model(
         tile_width: int,
         tile_height_extra: int,
         sub_rounds: int,
+        obs: int,
         style: str):
-    circuit = generate_honeycomb_circuit(
+    circuit = generate_honeycomb_circuit(HoneycombLayout(
         tile_width=tile_width,
         tile_height=tile_width + tile_height_extra,
         sub_rounds=sub_rounds,
         noise=0.001,
         style=style,
-    )
+        v_obs=bool(obs & 1),
+        h_obs=bool(obs & 2),
+    ))
     _ = circuit.detector_error_model(decompose_errors=True)
 
 
 def test_circuit_details_SD6():
-    actual = generate_honeycomb_circuit(
+    actual = generate_honeycomb_circuit(HoneycombLayout(
         tile_width=1,
         tile_height=1,
         sub_rounds=1003,
         noise=0.001,
         style="SD6",
-    )
+        v_obs=True,
+        h_obs=False,
+    ))
     cleaned = stim.Circuit(str(actual))
     assert cleaned == stim.Circuit("""
         QUBIT_COORDS(1, 0) 0
@@ -276,13 +283,15 @@ def test_circuit_details_SD6():
 
 
 def test_circuit_details_PC3():
-    actual = generate_honeycomb_circuit(
+    actual = generate_honeycomb_circuit(HoneycombLayout(
         tile_width=1,
         tile_height=1,
         sub_rounds=1003,
         noise=0.001,
         style="PC3",
-    )
+        v_obs=True,
+        h_obs=False,
+    ))
     cleaned = stim.Circuit(str(actual))
     assert cleaned == stim.Circuit("""
         QUBIT_COORDS(1, 0) 0
@@ -482,13 +491,15 @@ def test_circuit_details_PC3():
 
 
 def test_circuit_details_EM3():
-    actual = generate_honeycomb_circuit(
+    actual = generate_honeycomb_circuit(HoneycombLayout(
         tile_width=1,
         tile_height=1,
         sub_rounds=1003,
         noise=0.001,
         style="EM3",
-    )
+        v_obs=True,
+        h_obs=False,
+    ))
     cleaned = stim.Circuit(str(actual))
     assert cleaned == stim.Circuit("""
         QUBIT_COORDS(1, 0) 0

--- a/src/honeycomb_layout.py
+++ b/src/honeycomb_layout.py
@@ -72,8 +72,26 @@ SECOND_EDGES_AROUND_HEX: List[Tuple[complex, complex]] = [
 
 
 class HoneycombLayout:
-    def __init__(self, tile_diam: int, sub_rounds: int, noise: float, style: str):
-        self.tile_diam = tile_diam
+    """Computes information about the honeycomb code layout, such as hex face locations."""
+
+    def __init__(self,
+                 tile_width: int,
+                 tile_height: int,
+                 sub_rounds: int,
+                 noise: float,
+                 style: str):
+        """
+        Args:
+            tile_width: The number of times to horizontally repeat the tiling unit of the code.
+            tile_height: The number of times to vertically repeat the tiling unit of the code.
+            sub_rounds: The number of edge parity measurements to perform (counting X, Y, and Z
+                separately).
+            noise: Determines the strength of noisy operations, relative to the error model.
+            style: Determines details of the circuit layout and the error model used. Valid values are
+                "SD6", "EM3", "CP3", and "SI7".
+        """
+        self.tile_width = tile_width
+        self.tile_height = tile_height
         self.sub_rounds = sub_rounds
         self.noise = noise
         self.style = style
@@ -143,7 +161,7 @@ class HoneycombLayout:
         c, = set(obs_pattern) - {'_'}
         return c, [
             q
-            for c, q in zip(obs_pattern * self.tile_diam * 2, self.obs_1_qubits)
+            for c, q in zip(obs_pattern * self.tile_height * 2, self.obs_1_qubits)
             if c != "_"
         ]
 
@@ -187,11 +205,11 @@ class HoneycombLayout:
 
     @functools.cached_property
     def coord_width(self) -> float:
-        return 4.0 * self.tile_diam
+        return 4.0 * self.tile_width
 
     @functools.cached_property
     def coord_height(self) -> float:
-        return 6.0 * self.tile_diam
+        return 6.0 * self.tile_height
 
     @functools.lru_cache(maxsize=3)
     def round_hex_centers(self, r: int) -> Tuple[complex, ...]:
@@ -235,8 +253,8 @@ class HoneycombLayout:
     def _hex_center_categories(self) -> Dict[complex, int]:
         """Generate and categorize the hexes defining the circuit."""
         result: Dict[complex, int] = {}
-        for row in range(3 * self.tile_diam):
-            for col in range(2 * self.tile_diam):
+        for row in range(3 * self.tile_height):
+            for col in range(2 * self.tile_width):
                 center = row * 2j + 2 * col - 1j * (col % 2)
                 category = (-row - col % 2) % 3
                 result[self.wrap(center)] = category

--- a/src/honeycomb_layout.py
+++ b/src/honeycomb_layout.py
@@ -82,8 +82,7 @@ class HoneycombLayout:
                  sub_rounds: int,
                  noise: float,
                  style: str,
-                 v_obs: bool,
-                 h_obs: bool):
+                 obs: str):
         """
         Args:
             tile_width: The number of times to horizontally repeat the tiling unit of the code.
@@ -92,15 +91,19 @@ class HoneycombLayout:
                 separately).
             noise: Determines the strength of noisy operations, relative to the error model.
             style: Determines details of the circuit layout and the error model used. Valid values are
-                "SD6", "EM3", "CP3", and "SI7".
+                "SD6": Standard depolarizing circuit (w/ 6 step cycle).
+                "EM3": Entangling measurements circuit (w/ 3 step cycle).
+                "CP3": Controlled paulis circuit (w/ 3 step cycle).
+            obs: The observable to initialize and measure fault tolerantly. Valid values are:
+                "H": Horizontal observable.
+                "V": Vertical observable.
         """
         self.tile_width = tile_width
         self.tile_height = tile_height
         self.sub_rounds = sub_rounds
         self.noise = noise
         self.style = style
-        self.v_obs = v_obs
-        self.h_obs = h_obs
+        self.obs = obs
 
     @functools.cached_property
     def noise_model(self) -> NoiseModel:
@@ -182,11 +185,12 @@ class HoneycombLayout:
         ]
 
     def obs_before_sub_round(self, sub_round: int) -> Tuple[str, List[complex]]:
-        assert self.v_obs != self.h_obs
-        if self.v_obs:
+        if self.obs == "V":
             return self.obs_v_before_sub_round(sub_round)
-        else:
+        elif self.obs == "H":
             return self.obs_h_before_sub_round(sub_round)
+        else:
+            raise NotImplementedError(self.obs)
 
     def obs_v_before_sub_round(self, sub_round: int) -> Tuple[str, List[complex]]:
         case = sub_round % 6
@@ -308,27 +312,30 @@ class HoneycombLayout:
 
     @functools.cached_property
     def obs_index(self) -> int:
-        assert self.v_obs != self.h_obs
-        if self.v_obs:
+        if self.obs == "V":
             return 0
-        else:
+        elif self.obs == "H":
             return 1
+        else:
+            raise NotImplementedError(self.obs)
 
     @functools.cached_property
     def obs_edges(self) -> Tuple[Edge]:
-        assert self.v_obs != self.h_obs
-        if self.v_obs:
+        if self.obs == "V":
             return self.obs_v_edges
-        else:
+        elif self.obs == "H":
             return self.obs_h_edges
+        else:
+            raise NotImplementedError(self.obs)
 
     @functools.cached_property
     def obs_qubits(self) -> Tuple[complex]:
-        assert self.v_obs != self.h_obs
-        if self.v_obs:
+        if self.obs == "V":
             return self.obs_v_qubits
-        else:
+        elif self.obs == "H":
             return self.obs_h_qubits
+        else:
+            raise NotImplementedError(self.obs)
 
     @functools.cached_property
     def all_edges(self) -> Tuple[Edge, ...]:

--- a/src/honeycomb_layout_test.py
+++ b/src/honeycomb_layout_test.py
@@ -23,9 +23,9 @@ def diagram_2d(values: Dict[complex, Any]):
 
 
 def test_ctx():
-    ctx1 = HoneycombLayout(tile_width=1, tile_height=1, sub_rounds=18, noise=0.001, style="SD6")
-    ctx2 = HoneycombLayout(tile_width=2, tile_height=2, sub_rounds=18, noise=0.001, style="SD6")
-    ctx3 = HoneycombLayout(tile_width=3, tile_height=3, sub_rounds=18, noise=0.001, style="SD6")
+    ctx1 = HoneycombLayout(tile_width=1, tile_height=1, sub_rounds=18, noise=0.001, style="SD6", v_obs=True, h_obs=False)
+    ctx2 = HoneycombLayout(tile_width=2, tile_height=2, sub_rounds=18, noise=0.001, style="SD6", v_obs=True, h_obs=False)
+    ctx3 = HoneycombLayout(tile_width=3, tile_height=3, sub_rounds=18, noise=0.001, style="SD6", v_obs=True, h_obs=False)
 
     assert ctx1.wrap(-1) == 3
     assert ctx1.wrap(-1j) == 5j
@@ -97,14 +97,65 @@ def test_ctx():
     assert ctx1.round_hex_centers(1) == (4j, 2 + 1j)
     assert ctx1.round_hex_centers(2) == (2j, 2 + 5j)
     assert ctx2.round_hex_centers(0) == (0, 0 + 6j, 2 + 3j, 2 + 9j, 4, 4 + 6j, 6 + 3j, 6 + 9j)
-    assert ctx1.obs_1_qubits == (1, 1 + 1j, 1 + 2j, 1 + 3j, 1 + 4j, 1 + 5j)
-    assert ctx1.obs_1_edges == (
+    assert ctx1.obs_v_qubits == (1, 1 + 1j, 1 + 2j, 1 + 3j, 1 + 4j, 1 + 5j)
+    assert ctx1.obs_v_before_sub_round(0) == (
+        "Z",
+        [1 + 1j, 1 + 2j, 1 + 4j, 1 + 5j],
+    )
+
+    assert ctx1.obs_v_edges == (
         Edge(left=1 + 0j, right=1 + 1j, center=1 + 0.5j),
         Edge(left=1 + 1j, right=1 + 2j, center=1 + 1.5j),
         Edge(left=1 + 2j, right=1 + 3j, center=1 + 2.5j),
         Edge(left=1 + 3j, right=1 + 4j, center=1 + 3.5j),
         Edge(left=1 + 4j, right=1 + 5j, center=1 + 4.5j),
         Edge(left=1 + 5j, right=1 + 0j, center=1 + 5.5j),
+    )
+    assert ctx1.obs_h_qubits == (1 + 1j, 1, 3, 3 + 1j)
+    assert ctx2.obs_h_qubits == (
+        1 + 1j,
+        1,
+        3,
+        3 + 1j,
+        5 + 1j,
+        5,
+        7,
+        7 + 1j,
+    )
+    assert ctx1.obs_h_before_sub_round(0) == (
+        "X",
+        [1, 3],
+    )
+    assert ctx2.obs_h_before_sub_round(0) == (
+        "X",
+        [1, 3, 5, 7],
+    )
+    assert ctx2.obs_h_before_sub_round(1) == (
+        "X",
+        [1 + 1j, 1, 3, 3 + 1j, 5 + 1j, 5, 7, 7 + 1j],
+    )
+    assert ctx2.obs_h_before_sub_round(2) == (
+        "Z",
+        [1 + 1j, 1, 3, 3 + 1j, 5 + 1j, 5, 7, 7 + 1j],
+    )
+    assert ctx2.obs_h_before_sub_round(3) == (
+        "Z",
+        [1 + 1j, 3 + 1j, 5 + 1j, 7 + 1j],
+    )
+    assert ctx2.obs_h_before_sub_round(4) == (
+        "Y",
+        [1 + 1j, 3 + 1j, 5 + 1j, 7 + 1j],
+    )
+    assert ctx2.obs_h_before_sub_round(5) == (
+        "Y",
+        [1, 3, 5, 7],
+    )
+
+    assert ctx1.obs_h_edges == (
+        Edge(left=1 + 1j, right=3 + 1j, center=0 + 1j),
+        Edge(left=1 + 0j, right=1 + 1j, center=1 + 0.5j),
+        Edge(left=3 + 0j, right=1 + 0j, center=2 + 0j),
+        Edge(left=3 + 1j, right=3 + 0j, center=3 + 0.5j),
     )
     assert ctx1.round_edges(0) == (
         Edge(left=1 + 3j, right=3 + 3j, center=0 + 3j),
@@ -137,7 +188,7 @@ def test_ctx_layout():
     for k, v in ctx._hex_center_categories.items():
         d[scale(k)] = "XYZ"[v]
     for r in range(6):
-        p, qs = ctx.obs_1_before_sub_round(r)
+        p, qs = ctx.obs_v_before_sub_round(r)
         for q in qs:
             d[scale(q) + r + 1] = p
     assert diagram_2d(d).strip() == """

--- a/src/honeycomb_layout_test.py
+++ b/src/honeycomb_layout_test.py
@@ -23,9 +23,9 @@ def diagram_2d(values: Dict[complex, Any]):
 
 
 def test_ctx():
-    ctx1 = HoneycombLayout(tile_diam=1, sub_rounds=18, noise=0.001, style="SD6")
-    ctx2 = HoneycombLayout(tile_diam=2, sub_rounds=18, noise=0.001, style="SD6")
-    ctx3 = HoneycombLayout(tile_diam=3, sub_rounds=18, noise=0.001, style="SD6")
+    ctx1 = HoneycombLayout(tile_width=1, tile_height=1, sub_rounds=18, noise=0.001, style="SD6")
+    ctx2 = HoneycombLayout(tile_width=2, tile_height=2, sub_rounds=18, noise=0.001, style="SD6")
+    ctx3 = HoneycombLayout(tile_width=3, tile_height=3, sub_rounds=18, noise=0.001, style="SD6")
 
     assert ctx1.wrap(-1) == 3
     assert ctx1.wrap(-1j) == 5j
@@ -126,7 +126,7 @@ def test_ctx():
 
 
 def test_ctx_layout():
-    ctx = HoneycombLayout(tile_diam=2, sub_rounds=20, noise=0.001, style="SD6")
+    ctx = HoneycombLayout(tile_width=2, tile_height=2, sub_rounds=20, noise=0.001, style="SD6")
     def scale(pt: complex) -> complex:
         return pt.real * 8 + pt.imag * 2j
     d = {}
@@ -169,7 +169,7 @@ def test_ctx_layout():
 
 
 def test_ctx_indexing():
-    ctx = HoneycombLayout(tile_diam=1, sub_rounds=20, noise=0.001, style="SD6")
+    ctx = HoneycombLayout(tile_width=1, tile_height=1, sub_rounds=20, noise=0.001, style="SD6")
     def scale(pt: complex) -> complex:
         return pt.real * 4 + pt.imag * 2j
     d = {}

--- a/src/honeycomb_layout_test.py
+++ b/src/honeycomb_layout_test.py
@@ -23,9 +23,9 @@ def diagram_2d(values: Dict[complex, Any]):
 
 
 def test_ctx():
-    ctx1 = HoneycombLayout(tile_width=1, tile_height=1, sub_rounds=18, noise=0.001, style="SD6", v_obs=True, h_obs=False)
-    ctx2 = HoneycombLayout(tile_width=2, tile_height=2, sub_rounds=18, noise=0.001, style="SD6", v_obs=True, h_obs=False)
-    ctx3 = HoneycombLayout(tile_width=3, tile_height=3, sub_rounds=18, noise=0.001, style="SD6", v_obs=True, h_obs=False)
+    ctx1 = HoneycombLayout(tile_width=1, tile_height=1, sub_rounds=18, noise=0.001, style="SD6", obs="V")
+    ctx2 = HoneycombLayout(tile_width=2, tile_height=2, sub_rounds=18, noise=0.001, style="SD6", obs="V")
+    ctx3 = HoneycombLayout(tile_width=3, tile_height=3, sub_rounds=18, noise=0.001, style="SD6", obs="V")
 
     assert ctx1.wrap(-1) == 3
     assert ctx1.wrap(-1j) == 5j
@@ -124,31 +124,31 @@ def test_ctx():
     )
     assert ctx1.obs_h_before_sub_round(0) == (
         "X",
-        [1, 3],
+        [1 + 1j, 1, 3, 3 + 1j],
     )
     assert ctx2.obs_h_before_sub_round(0) == (
         "X",
-        [1, 3, 5, 7],
+        [1 + 1j, 1, 3, 3 + 1j, 5 + 1j, 5, 7, 7 + 1j],
     )
     assert ctx2.obs_h_before_sub_round(1) == (
         "X",
-        [1 + 1j, 1, 3, 3 + 1j, 5 + 1j, 5, 7, 7 + 1j],
+        [1 + 1j, 3 + 1j, 5 + 1j, 7 + 1j],
     )
     assert ctx2.obs_h_before_sub_round(2) == (
         "Z",
-        [1 + 1j, 1, 3, 3 + 1j, 5 + 1j, 5, 7, 7 + 1j],
+        [1 + 1j, 3 + 1j, 5 + 1j, 7 + 1j],
     )
     assert ctx2.obs_h_before_sub_round(3) == (
         "Z",
-        [1 + 1j, 3 + 1j, 5 + 1j, 7 + 1j],
+        [1, 3, 5, 7],
     )
     assert ctx2.obs_h_before_sub_round(4) == (
         "Y",
-        [1 + 1j, 3 + 1j, 5 + 1j, 7 + 1j],
+        [1, 3, 5, 7],
     )
     assert ctx2.obs_h_before_sub_round(5) == (
         "Y",
-        [1, 3, 5, 7],
+        [1 + 1j, 1, 3, 3 + 1j, 5 + 1j, 5, 7, 7 + 1j],
     )
 
     assert ctx1.obs_h_edges == (
@@ -177,7 +177,7 @@ def test_ctx():
 
 
 def test_ctx_layout():
-    ctx = HoneycombLayout(tile_width=2, tile_height=2, sub_rounds=20, noise=0.001, style="SD6")
+    ctx = HoneycombLayout(tile_width=2, tile_height=2, sub_rounds=20, noise=0.001, style="SD6", obs="V")
     def scale(pt: complex) -> complex:
         return pt.real * 8 + pt.imag * 2j
     d = {}
@@ -220,7 +220,7 @@ def test_ctx_layout():
 
 
 def test_ctx_indexing():
-    ctx = HoneycombLayout(tile_width=1, tile_height=1, sub_rounds=20, noise=0.001, style="SD6")
+    ctx = HoneycombLayout(tile_width=1, tile_height=1, sub_rounds=20, noise=0.001, style="SD6", obs="V")
     def scale(pt: complex) -> complex:
         return pt.real * 4 + pt.imag * 2j
     d = {}

--- a/src/main_example.py
+++ b/src/main_example.py
@@ -13,9 +13,8 @@ def main():
                 tile_width=d,
                 tile_height=d,
                 sub_rounds=30,
-                style="SD6",
-                v_obs=True,
-                h_obs=False,
+                style="EM3",
+                obs="V",
             )
             for d in [2, 3, 4]
             for p in [0.001, 0.002, 0.003]

--- a/src/main_example.py
+++ b/src/main_example.py
@@ -14,6 +14,8 @@ def main():
                 tile_height=d,
                 sub_rounds=30,
                 style="SD6",
+                v_obs=True,
+                h_obs=False,
             )
             for d in [2, 3, 4]
             for p in [0.001, 0.002, 0.003]

--- a/src/main_example.py
+++ b/src/main_example.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-from experiment import collect_simulated_experiment_data, plot_data
+from collect_data import collect_simulated_experiment_data
 from honeycomb_layout import HoneycombLayout
+from plotting import plot_data
 
 
 def main():
@@ -9,12 +10,13 @@ def main():
         *[
             HoneycombLayout(
                 noise=p,
-                tile_diam=d,
+                tile_width=d,
+                tile_height=d,
                 sub_rounds=30,
                 style="SD6",
             )
             for d in [2, 3, 4]
-            for p in np.geomspace(start=5e-4, stop=3e-3, num=5)
+            for p in [0.001, 0.002, 0.003]
         ],
         out_path="test.csv",
         discard_previous_data=True,

--- a/src/noise.py
+++ b/src/noise.py
@@ -4,7 +4,7 @@ from typing import Optional, Dict, Set, Tuple
 import stim
 
 ANY_CLIFFORD_1_OPS = {"C_XYZ", "C_ZYX", "H", "H_YZ", "I"}
-ANY_CLIFFORD_2_OPS = {"CX", "XCX", "YCX", "CZ", "CY", "YCX", "YCY"}
+ANY_CLIFFORD_2_OPS = {"CX", "CY", "CZ", "XCX", "XCY", "XCZ", "YCX", "YCY", "YCZ"}
 RESET_OPS = {"R", "RX", "RY"}
 MEASURE_OPS = {"M", "MX", "MY"}
 ANNOTATION_OPS = {"OBSERVABLE_INCLUDE", "DETECTOR", "SHIFT_COORDS", "QUBIT_COORDS", "TICK"}

--- a/src/noise.py
+++ b/src/noise.py
@@ -3,7 +3,7 @@ from typing import Optional, Dict, Set, Tuple
 
 import stim
 
-ANY_CLIFFORD_1_OPS = {"C_XYZ", "H", "H_YZ"}
+ANY_CLIFFORD_1_OPS = {"C_XYZ", "C_ZYX", "H", "H_YZ", "I"}
 ANY_CLIFFORD_2_OPS = {"CX", "XCX", "YCX", "CZ", "CY", "YCX", "YCY"}
 RESET_OPS = {"R", "RX", "RY"}
 MEASURE_OPS = {"M", "MX", "MY"}

--- a/src/paper/main_collect_EM3.py
+++ b/src/paper/main_collect_EM3.py
@@ -11,7 +11,8 @@ def main():
         *[
             HoneycombLayout(
                 noise=p,
-                tile_diam=d,
+                tile_width=d,
+                tile_height=d,
                 sub_rounds=30,
                 style="EM3",
             )

--- a/src/paper/main_collect_EM3.py
+++ b/src/paper/main_collect_EM3.py
@@ -15,6 +15,7 @@ def main():
                 tile_height=d,
                 sub_rounds=30,
                 style="EM3",
+                obs="V",
             )
             for p in [1e-4, 2e-4, 5e-4, 1e-3, 2e-3, 5e-3, 1e-2, 2e-2, 5e-2]
             for d in [1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/src/paper/main_collect_PC3.py
+++ b/src/paper/main_collect_PC3.py
@@ -11,7 +11,8 @@ def main():
         *[
             HoneycombLayout(
                 noise=p,
-                tile_diam=d,
+                tile_width=d,
+                tile_height=d,
                 sub_rounds=d * 6,
                 style="PC3",
             )

--- a/src/paper/main_collect_PC3.py
+++ b/src/paper/main_collect_PC3.py
@@ -15,6 +15,7 @@ def main():
                 tile_height=d,
                 sub_rounds=d * 6,
                 style="PC3",
+                obs="V",
             )
             for p in [1e-4, 2e-4, 5e-4, 1e-3, 2e-3, 5e-3, 1e-2, 2e-2, 5e-2]
             for d in [1, 2, 3, 4, 5, 6, 7, 8, 9]

--- a/src/paper/main_collect_SD6.py
+++ b/src/paper/main_collect_SD6.py
@@ -11,7 +11,8 @@ def main():
         *[
             HoneycombLayout(
                 noise=p,
-                tile_diam=d,
+                tile_width=d,
+                tile_height=d,
                 sub_rounds=30,
                 style="SD6",
             )

--- a/src/paper/main_collect_SD6.py
+++ b/src/paper/main_collect_SD6.py
@@ -15,6 +15,7 @@ def main():
                 tile_height=d,
                 sub_rounds=30,
                 style="SD6",
+                obs="V",
             )
             for p in [1e-4, 2e-4, 5e-4, 1e-3, 2e-3, 5e-3, 1e-2, 2e-2, 5e-2]
             for d in [1, 2, 3, 4, 5, 6, 7, 8, 9]


### PR DESCRIPTION
- Split `tile_diam` into `tile_width` and `tile_height`
- Add `obs` string parameter to `HoneycombLayout`
- Make circuit generation take a `HoneycombLayout` instead of its parameters
- Add unit tests checking data collection and data plotting run to completion without throwing
- Fix the sd6 circuit rotating qubits backwards instead of forwards (doing subrounds YXZ instead of XYZ).